### PR TITLE
[Agent] Fix: UX bug : Task hover card disappears when moving mouse into it (only when displayed below task)

### DIFF
--- a/HoverCard.vue
+++ b/HoverCard.vue
@@ -1,0 +1,88 @@
+```vue
+<template>
+  <div
+    ref="hoverCard"
+    class="hover-card"
+    :class="{ 'is-visible': isVisible }"
+    @mouseover="handleMouseOver"
+    @mouseout="handleMouseOut"
+  >
+    <slot />
+  </div>
+</template>
+
+<script>
+import { debounce } from 'lodash-es';
+
+export default {
+  name: 'HoverCard',
+  props: {
+    taskId: {
+      type: String,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      isVisible: false,
+      hideDebounced: debounce(() => {
+        this.isVisible = false;
+      }, 100),
+    };
+  },
+  methods: {
+    handleMouseOver() {
+      this.hideDebounced.cancel();
+      this.isVisible = true;
+    },
+    handleMouseOut(event) {
+      const relatedTarget = event.relatedTarget;
+      if (!relatedTarget || !this.$refs.hoverCard.contains(relatedTarget)) {
+        this.hideDebounced();
+      }
+    },
+    updatePosition() {
+      if (this.isVisible && this.$refs.hoverCard) {
+        this.$nextTick(() => {
+          const { top, left } = this.$parent.$el.getBoundingClientRect();
+          this.$refs.hoverCard.style.top = `${top - this.$refs.hoverCard.offsetHeight - 8}px`;
+          this.$refs.hoverCard.style.left = `${left}px`;
+        });
+      }
+    },
+  },
+  watch: {
+    isVisible(newVal) {
+      if (newVal) {
+        this.updatePosition();
+      }
+    },
+  },
+  mounted() {
+    window.addEventListener('resize', this.updatePosition);
+  },
+  beforeDestroy() {
+    window.removeEventListener('resize', this.updatePosition);
+    this.hideDebounced.cancel();
+  },
+};
+</script>
+
+<style scoped>
+.hover-card {
+  position: fixed;
+  z-index: 1000;
+  background: white;
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  pointer-events: auto;
+  padding: 8px 0;
+}
+
+.hover-card.is-visible {
+  opacity: 1;
+}
+</style>
+```

--- a/Popper.js
+++ b/Popper.js
@@ -1,0 +1,41 @@
+```javascript
+import { createPopper } from '@popperjs/core';
+
+export default {
+  methods: {
+    setupPopper(element, popper, options = {}) {
+      const defaultOptions = {
+        placement: 'top',
+        modifiers: [
+          {
+            name: 'preventOverflow',
+            options: {
+              padding: 8,
+              boundariesElement: 'viewport'
+            }
+          },
+          {
+            name: 'flip',
+            options: {
+              fallbackPlacements: ['top', 'bottom']
+            }
+          }
+        ],
+        ...options
+      };
+
+      return createPopper(element, popper, defaultOptions);
+    },
+    updatePopper(popperInstance) {
+      if (popperInstance) {
+        popperInstance.update();
+      }
+    },
+    destroyPopper(popperInstance) {
+      if (popperInstance) {
+        popperInstance.destroy();
+      }
+    }
+  }
+};
+```

--- a/Task.vue
+++ b/Task.vue
@@ -1,0 +1,74 @@
+```vue
+<template>
+  <div class="task" @mouseover="handleMouseOver" @mouseout="handleMouseOut">
+    <div class="task-content">
+      <input type="checkbox" v-model="task.completed" @click.stop />
+      <span>{{ task.title }}</span>
+    </div>
+    <HoverCard
+      v-if="showHoverCard"
+      :task="task"
+      @mouseenter="cancelHide"
+      @mouseleave="scheduleHide"
+    />
+  </div>
+</template>
+
+<script>
+import HoverCard from './HoverCard.vue'
+import { debounce } from 'lodash'
+
+export default {
+  components: { HoverCard },
+  props: {
+    task: { type: Object, required: true }
+  },
+  data() {
+    return {
+      showHoverCard: false,
+      hideDebounce: null
+    }
+  },
+  methods: {
+    handleMouseOver(event) {
+      if (!this.isRelatedTargetHoverCard(event)) {
+        this.showHoverCard = true
+        this.cancelHide()
+      }
+    },
+    handleMouseOut(event) {
+      if (!this.isRelatedTargetHoverCard(event)) {
+        this.scheduleHide()
+      }
+    },
+    isRelatedTargetHoverCard(event) {
+      return event.relatedTarget?.closest('.hover-card')
+    },
+    scheduleHide() {
+      this.hideDebounce = debounce(() => {
+        this.showHoverCard = false
+      }, 100)
+      this.hideDebounce()
+    },
+    cancelHide() {
+      if (this.hideDebounce) {
+        this.hideDebounce.cancel()
+      }
+    }
+  }
+}
+</script>
+
+<style scoped>
+.task {
+  position: relative;
+  padding: 8px 0;
+}
+
+.task-content {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+</style>
+```

--- a/src/components/HoverCard.vue
+++ b/src/components/HoverCard.vue
@@ -1,0 +1,61 @@
+```vue
+<template>
+  <div
+    v-if="isVisible"
+    ref="hoverCard"
+    class="hover-card"
+    @mouseover="handleMouseOver"
+    @mouseout="handleMouseOut"
+  >
+    <slot />
+  </div>
+</template>
+
+<script>
+import { debounce } from 'lodash';
+
+export default {
+  name: 'HoverCard',
+  props: {
+    target: {
+      type: HTMLElement,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      isVisible: false,
+    };
+  },
+  methods: {
+    handleMouseOver() {
+      this.isVisible = true;
+    },
+    handleMouseOut(event) {
+      if (!this.$el.contains(event.relatedTarget) && event.relatedTarget !== this.target) {
+        this.debouncedHide();
+      }
+    },
+    debouncedHide: debounce(function() {
+      this.isVisible = false;
+    }, 100),
+  },
+  mounted() {
+    this.target.addEventListener('mouseover', this.handleMouseOver);
+    this.target.addEventListener('mouseout', this.handleMouseOut);
+  },
+  beforeDestroy() {
+    this.target.removeEventListener('mouseover', this.handleMouseOver);
+    this.target.removeEventListener('mouseout', this.handleMouseOut);
+  },
+};
+</script>
+
+<style scoped>
+.hover-card {
+  position: absolute;
+  z-index: 1000;
+  padding: 8px 0;
+}
+</style>
+```

--- a/src/components/Task.vue
+++ b/src/components/Task.vue
@@ -1,0 +1,70 @@
+```vue
+<template>
+  <div
+    class="task"
+    @mouseover="handleMouseOver"
+    @mouseout="handleMouseOut"
+  >
+    <div class="task-content">
+      <slot></slot>
+    </div>
+    <HoverCard
+      v-if="showHoverCard"
+      ref="hoverCard"
+      :task="task"
+      class="task-hover-card"
+    />
+  </div>
+</template>
+
+<script>
+import HoverCard from './HoverCard.vue'
+import { debounce } from 'lodash'
+
+export default {
+  components: { HoverCard },
+  props: {
+    task: {
+      type: Object,
+      required: true
+    }
+  },
+  data() {
+    return {
+      showHoverCard: false,
+      hideDebounced: debounce(() => {
+        this.showHoverCard = false
+      }, 100)
+    }
+  },
+  methods: {
+    handleMouseOver(event) {
+      if (!this.isHoverCard(event.relatedTarget)) {
+        this.showHoverCard = true
+        this.hideDebounced.cancel()
+      }
+    },
+    handleMouseOut(event) {
+      if (!this.isHoverCard(event.relatedTarget)) {
+        this.hideDebounced()
+      }
+    },
+    isHoverCard(element) {
+      return element === this.$refs.hoverCard?.$el || 
+             this.$refs.hoverCard?.$el.contains(element)
+    }
+  }
+}
+</script>
+
+<style scoped>
+.task {
+  position: relative;
+  padding-bottom: 4px;
+}
+
+.task-hover-card {
+  margin-top: 4px;
+}
+</style>
+```

--- a/store.js
+++ b/store.js
@@ -1,0 +1,53 @@
+Вот обновленный код файла `store.js`:
+
+```javascript
+export default {
+  state: {
+    hoveredTaskId: null,
+    hoverCardPosition: { top: 0, left: 0 },
+    hoverCardVisible: false,
+    hoverCardTimeout: null
+  },
+  mutations: {
+    setHoveredTask(state, taskId) {
+      state.hoveredTaskId = taskId
+    },
+    setHoverCardPosition(state, position) {
+      state.hoverCardPosition = position
+    },
+    setHoverCardVisible(state, isVisible) {
+      state.hoverCardVisible = isVisible
+    },
+    setHoverCardTimeout(state, timeout) {
+      if (state.hoverCardTimeout) {
+        clearTimeout(state.hoverCardTimeout)
+      }
+      state.hoverCardTimeout = timeout
+    }
+  },
+  actions: {
+    showHoverCard({ commit }, { taskId, position }) {
+      commit('setHoveredTask', taskId)
+      commit('setHoverCardPosition', position)
+      commit('setHoverCardVisible', true)
+    },
+    hideHoverCard({ commit, state }) {
+      const timeout = setTimeout(() => {
+        if (!document.querySelector('.hover-card:hover')) {
+          commit('setHoverCardVisible', false)
+          commit('setHoveredTask', null)
+        }
+      }, 100)
+      commit('setHoverCardTimeout', timeout)
+    },
+    updateHoverCardPosition({ commit }, position) {
+      commit('setHoverCardPosition', position)
+    }
+  },
+  getters: {
+    isTaskHovered: state => taskId => {
+      return state.hoveredTaskId === taskId
+    }
+  }
+}
+```


### PR DESCRIPTION
Closes #1

## Plan
**План решения:**

1. **Анализ текущей реализации ховер-карты**  
   - Изучить код компонента задачи и ховер-карты (вероятно, `Task.vue` или `HoverCard.vue`).  
   - Проверить логику позиционирования (используется ли `@popperjs/core` или кастомное решение).  

2. **Исправление зоны взаимодействия**  
   - Добавить ховер-карту в DOM-дерево так, чтобы она была дочерним элементом задачи (или связана через `parent-child`), чтобы события мыши не прерывались.  
   - Убедиться, что между задачей и ховер-картой нет "мертвой зоны" (например, добавить `padding` или `margin`).  

3. **Оптимизация событий мыши**  
   - Заменить `mouseenter/mouseleave` на `mouseover/mouseout` с проверкой `relatedTarget`, чтобы корректно обрабатывать переход между задачей и ховер-картой.  
   - Добавить задержку (debounce) для скрытия ховер-карты (например, 100 мс).  

4. **Позиционирование ховер-карты**  
   - Если используется Popper.js, проверить модификаторы (например, `preventOverflow` или `flip`).  
   - Добавить приоритет позиционирования сверху, если снизу недостаточно места (через `placement: 'top'` в Popper).  

5. **Тестирование**  
   - Проверить поведение на разных разрешениях экрана.  
   - Убедиться, что клики по ховер-карте (например, отметка задачи) работают корректно.  

**Файлы для изменения:**  
- `src/components/Task.vue` (основной компонент задачи)  
- `src/components/HoverCard.vue` (или аналогичный, если есть)  
- Возможно, стили в `src/assets/scss/` (если требуется поправить отступы).  

**Дополнительно:**  
- Если используется глобальное хранилище (Vuex), проверить логику состояний ховера в `store.js`.