### PR TITLE
[Agent] Fix: UX bug : Task hover card disappears when moving mouse into it (only when displayed below task)

### DIFF
--- a/Popper.js
+++ b/Popper.js
@@ -1,0 +1,33 @@
+```javascript
+import { createPopper } from '@popperjs/core';
+
+export default {
+  methods: {
+    setupPopper(el, popper, placement) {
+      return createPopper(el, popper, {
+        placement,
+        modifiers: [
+          {
+            name: 'offset',
+            options: {
+              offset: [0, 8],
+            },
+          },
+          {
+            name: 'preventOverflow',
+            options: {
+              padding: 8,
+            },
+          },
+          {
+            name: 'flip',
+            options: {
+              fallbackPlacements: ['top', 'bottom'],
+            },
+          },
+        ],
+      });
+    },
+  },
+};
+```

--- a/TaskItem.vue
+++ b/TaskItem.vue
@@ -1,0 +1,82 @@
+```vue
+<template>
+  <div 
+    class="task-item"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <div class="task-content">
+      <!-- Task content here -->
+    </div>
+
+    <div
+      v-if="showHoverCard"
+      class="hover-card"
+      :class="{ 'hover-card-top': showOnTop }"
+      @mouseenter="cancelHide"
+      @mouseleave="hideHoverCard"
+    >
+      <!-- Hover card content here -->
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      showHoverCard: false,
+      showOnTop: false,
+      hideTimeout: null
+    }
+  },
+  methods: {
+    handleMouseEnter() {
+      clearTimeout(this.hideTimeout)
+      this.calculatePosition()
+      this.showHoverCard = true
+    },
+    handleMouseLeave() {
+      this.hideTimeout = setTimeout(() => {
+        this.showHoverCard = false
+      }, 200)
+    },
+    cancelHide() {
+      clearTimeout(this.hideTimeout)
+    },
+    hideHoverCard() {
+      this.hideTimeout = setTimeout(() => {
+        this.showHoverCard = false
+      }, 200)
+    },
+    calculatePosition() {
+      const rect = this.$el.getBoundingClientRect()
+      this.showOnTop = rect.bottom + 200 > window.innerHeight
+    }
+  }
+}
+</script>
+
+<style scoped>
+.task-item {
+  position: relative;
+  padding-bottom: 8px;
+}
+
+.hover-card {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  z-index: 10;
+  pointer-events: auto;
+}
+
+.hover-card-top {
+  bottom: calc(100% + 8px);
+}
+
+.hover-card:not(.hover-card-top) {
+  top: calc(100% + 8px);
+}
+</style>
+```

--- a/src/components/TaskHoverCard.vue
+++ b/src/components/TaskHoverCard.vue
@@ -1,0 +1,65 @@
+```vue
+<template>
+  <div
+    class="task-hover-card"
+    :style="positionStyle"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <slot />
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    position: {
+      type: String,
+      default: 'bottom',
+      validator: (value) => ['top', 'bottom'].includes(value),
+    },
+    offset: {
+      type: Number,
+      default: 8,
+    },
+  },
+  data() {
+    return {
+      isVisible: false,
+      hoverTimeout: null,
+    };
+  },
+  computed: {
+    positionStyle() {
+      return {
+        [this.position === 'top' ? 'bottom' : 'top']: `calc(100% + ${this.offset}px)`,
+      };
+    },
+  },
+  methods: {
+    handleMouseEnter() {
+      clearTimeout(this.hoverTimeout);
+      this.isVisible = true;
+    },
+    handleMouseLeave() {
+      this.hoverTimeout = setTimeout(() => {
+        this.isVisible = false;
+      }, 200);
+    },
+    cancelHoverTimeout() {
+      clearTimeout(this.hoverTimeout);
+    },
+  },
+};
+</script>
+
+<style scoped>
+.task-hover-card {
+  position: absolute;
+  left: 0;
+  z-index: 10;
+  pointer-events: auto;
+  transition: opacity 0.2s ease;
+}
+</style>
+```

--- a/src/components/TaskItem.vue
+++ b/src/components/TaskItem.vue
@@ -1,0 +1,85 @@
+```vue
+<template>
+  <div class="task-item" @mouseenter="handleMouseEnter" @mouseleave="handleMouseLeave">
+    <div class="task-content">
+      <slot></slot>
+    </div>
+    <div 
+      v-if="showHoverCard" 
+      class="hover-card" 
+      :class="{ 'hover-card-bottom': showBelow }"
+      @mouseenter="handleCardEnter"
+      @mouseleave="handleCardLeave"
+    >
+      <slot name="hover-content"></slot>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'TaskItem',
+  data() {
+    return {
+      showHoverCard: false,
+      showBelow: false,
+      hoverTimeout: null,
+      isHoveringCard: false
+    }
+  },
+  methods: {
+    handleMouseEnter() {
+      clearTimeout(this.hoverTimeout)
+      this.showBelow = this.checkPosition()
+      this.hoverTimeout = setTimeout(() => {
+        this.showHoverCard = true
+      }, 200)
+    },
+    handleMouseLeave() {
+      this.hoverTimeout = setTimeout(() => {
+        if (!this.isHoveringCard) {
+          this.showHoverCard = false
+        }
+      }, 300)
+    },
+    handleCardEnter() {
+      clearTimeout(this.hoverTimeout)
+      this.isHoveringCard = true
+    },
+    handleCardLeave() {
+      this.isHoveringCard = false
+      this.hoverTimeout = setTimeout(() => {
+        this.showHoverCard = false
+      }, 200)
+    },
+    checkPosition() {
+      const rect = this.$el.getBoundingClientRect()
+      return rect.bottom + 200 > window.innerHeight
+    }
+  }
+}
+</script>
+
+<style scoped>
+.task-item {
+  position: relative;
+  cursor: pointer;
+}
+
+.hover-card {
+  position: absolute;
+  z-index: 10;
+  left: 0;
+  top: 100%;
+  margin-top: 8px;
+  pointer-events: auto;
+}
+
+.hover-card-bottom {
+  top: auto;
+  bottom: 100%;
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+</style>
+```


### PR DESCRIPTION
Closes #1

## Plan
**План решения:**

1. **Анализ компонента hover card**  
   - Найти компонент/файл, отвечающий за отображение hover card (вероятно, `TaskItem.vue` или подобный)
   - Проверить логику позиционирования (верх/низ) и обработчики событий (`mouseenter`, `mouseleave`)

2. **Модификация hover-логики**  
   - Добавить задержку (`setTimeout`) перед скрытием карточки при `mouseleave`  
   - Или расширить hover-область, включив в нее саму карточку через CSS (`pointer-events`)

3. **Проверка позиционирования**  
   - Убедиться, что карточка не перекрывает соседние элементы при отображении снизу  
   - Возможно, добавить отступ между карточкой и следующей задачей

4. **Обновление обработчиков событий**  
   - Добавить проверку: если курсор вошел в hover card, не скрывать ее  
   - Использовать `mouseenter/mouseleave` для самого контейнера карточки

5. **Тестирование**  
   - Проверить поведение при разном количестве задач  
   - Убедиться, что клики по карточке работают корректно  

**Файлы для изменения:**  
- `src/components/TaskItem.vue` (основной компонент задачи)  
- Возможно `src/components/TaskHoverCard.vue` (если карточка вынесена отдельно)  
- Стили (SCSS/CSS) для hover-области  

**Дополнительно:**  
Если используется Popper.js (указан в зависимостях), проверить его конфигурацию для позиционирования.