### PR TITLE
[Agent] Fix: UX bug : Task hover card disappears when moving mouse into it (only when displayed below task)

### DIFF
--- a/Task.scss
+++ b/Task.scss
@@ -1,0 +1,29 @@
+```scss
+.task {
+  position: relative;
+  cursor: pointer;
+
+  &-hover-card {
+    position: absolute;
+    z-index: 10;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+    margin-top: 4px;
+
+    &--top {
+      bottom: calc(100% + 8px);
+    }
+
+    &--bottom {
+      top: calc(100% + 8px);
+    }
+  }
+
+  &:hover &-hover-card,
+  &-hover-card:hover {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+```

--- a/Task.vue
+++ b/Task.vue
@@ -1,0 +1,78 @@
+```vue
+<template>
+  <div class="task" @mouseenter="handleMouseEnter" @mouseleave="handleMouseLeave">
+    <div class="task-content">
+      <!-- Task content here -->
+    </div>
+    <div 
+      class="hover-card" 
+      :class="{'hover-card--top': position === 'top', 'hover-card--bottom': position === 'bottom'}"
+      @mouseenter="isHoveringCard = true"
+      @mouseleave="isHoveringCard = false"
+      v-show="isHovering"
+      ref="hoverCard"
+    >
+      <!-- Hover card content here -->
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      isHovering: false,
+      isHoveringCard: false,
+      position: 'bottom'
+    }
+  },
+  methods: {
+    handleMouseEnter() {
+      this.isHovering = true
+      this.calculatePosition()
+    },
+    handleMouseLeave() {
+      setTimeout(() => {
+        if (!this.isHoveringCard) {
+          this.isHovering = false
+        }
+      }, 100)
+    },
+    calculatePosition() {
+      const rect = this.$el.getBoundingClientRect()
+      const spaceBelow = window.innerHeight - rect.bottom
+      const spaceAbove = rect.top
+      this.position = spaceBelow > spaceAbove ? 'bottom' : 'top'
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.task {
+  position: relative;
+  cursor: pointer;
+
+  &:hover .hover-card {
+    opacity: 1;
+    visibility: visible;
+  }
+}
+
+.hover-card {
+  position: absolute;
+  z-index: 10;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.2s ease, visibility 0.2s ease;
+
+  &--top {
+    bottom: calc(100% + 8px);
+  }
+
+  &--bottom {
+    top: calc(100% + 8px);
+  }
+}
+</style>
+```

--- a/src/components/Task/Task.scss
+++ b/src/components/Task/Task.scss
@@ -1,0 +1,33 @@
+```scss
+.task {
+  position: relative;
+  cursor: pointer;
+
+  &__hover-card {
+    position: absolute;
+    z-index: 10;
+    width: 100%;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+
+    &--top {
+      bottom: calc(100% + 8px);
+    }
+
+    &--bottom {
+      top: calc(100% + 8px);
+    }
+
+    &-visible {
+      pointer-events: auto;
+      opacity: 1;
+    }
+  }
+
+  &:hover &__hover-card {
+    pointer-events: auto;
+    opacity: 1;
+  }
+}
+```

--- a/src/components/Task/Task.vue
+++ b/src/components/Task/Task.vue
@@ -1,0 +1,85 @@
+```vue
+<template>
+  <div class="task" @mouseenter="handleMouseEnter" @mouseleave="handleMouseLeave">
+    <div class="task-content">
+      <!-- Task content here -->
+    </div>
+    <div 
+      class="hover-card" 
+      :class="{ 'hover-card--top': isTopPositioned }"
+      v-show="isHovered"
+      @mouseenter="handleCardMouseEnter"
+      @mouseleave="handleCardMouseLeave"
+    >
+      <!-- Hover card content here -->
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      isHovered: false,
+      isTopPositioned: false,
+      hoverTimeout: null
+    }
+  },
+  methods: {
+    handleMouseEnter() {
+      clearTimeout(this.hoverTimeout)
+      this.isHovered = true
+      this.calculatePosition()
+    },
+    handleMouseLeave() {
+      this.hoverTimeout = setTimeout(() => {
+        if (!this.isCardHovered) {
+          this.isHovered = false
+        }
+      }, 100)
+    },
+    handleCardMouseEnter() {
+      clearTimeout(this.hoverTimeout)
+      this.isCardHovered = true
+    },
+    handleCardMouseLeave() {
+      this.isCardHovered = false
+      this.isHovered = false
+    },
+    calculatePosition() {
+      const rect = this.$el.getBoundingClientRect()
+      this.isTopPositioned = rect.top > window.innerHeight / 2
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.task {
+  position: relative;
+  cursor: pointer;
+
+  &:hover {
+    .hover-card {
+      opacity: 1;
+      pointer-events: auto;
+    }
+  }
+}
+
+.hover-card {
+  position: absolute;
+  z-index: 10;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+  margin-top: 8px;
+
+  &--top {
+    bottom: 100%;
+    margin-top: 0;
+    margin-bottom: 8px;
+  }
+}
+</style>
+```

--- a/src/utils/positioning.js
+++ b/src/utils/positioning.js
@@ -1,0 +1,38 @@
+```javascript
+export function calculateHoverPosition(element, hoverElement, margin = 8) {
+  const rect = element.getBoundingClientRect();
+  const hoverRect = hoverElement.getBoundingClientRect();
+  const viewportHeight = window.innerHeight;
+
+  const spaceAbove = rect.top;
+  const spaceBelow = viewportHeight - rect.bottom;
+
+  const position = {
+    left: rect.left + window.scrollX,
+    top: null,
+    isAbove: false
+  };
+
+  if (spaceBelow > hoverRect.height || spaceBelow > spaceAbove) {
+    position.top = rect.bottom + window.scrollY + margin;
+    position.isAbove = false;
+  } else {
+    position.top = rect.top + window.scrollY - hoverRect.height - margin;
+    position.isAbove = true;
+  }
+
+  return position;
+}
+
+export function isCursorBetweenElements(element, hoverElement, clientX, clientY) {
+  const elementRect = element.getBoundingClientRect();
+  const hoverRect = hoverElement.getBoundingClientRect();
+
+  const betweenX = clientX >= Math.min(elementRect.left, hoverRect.left) && 
+                   clientX <= Math.max(elementRect.right, hoverRect.right);
+  const betweenY = clientY >= Math.min(elementRect.top, hoverRect.top) && 
+                   clientY <= Math.max(elementRect.bottom, hoverRect.bottom);
+
+  return betweenX && betweenY;
+}
+```


### PR DESCRIPTION
Closes #1

## Plan
**План решения:**

1. **Анализ текущей реализации**  
   - Изучить код компонента задачи и hover-карточки (вероятно, `Task.vue` или подобный)
   - Проверить логику позиционирования hover-карточки (верх/низ) и обработчики событий `mouseenter/mouseleave`

2. **Исправление зоны взаимодействия**  
   - Модифицировать hover-логику, чтобы карточка считалась частью области задачи  
   - Добавить проверку: если курсор перемещается на карточку, не снимать hover-состояние

3. **Оптимизация позиционирования**  
   - В файле стилей (например, `Task.scss`) или JS-логике позиционирования добавить отступ между задачей и карточкой при нижнем позиционировании

4. **Тестирование edge-cases**  
   - Проверить поведение при быстром перемещении курсора  
   - Убедиться, что карточки соседних задач не перекрываются некорректно

5. **Файлы для изменения:**  
   - `src/components/Task/Task.vue` (основная логика)  
   - `src/components/Task/Task.scss` (стили позиционирования)  
   - Возможно `src/utils/positioning.js` (если есть отдельная логика позиционирования)

**Ключевая идея:**  
Нужно связать hover-карточку и задачу в единую интерактивную зону, используя либо общий родительский контейнер, либо отслеживание координат курсора при переходе между элементами.