### PR TITLE
[Agent] Fix: UX bug : Task hover card disappears when moving mouse into it (only when displayed below task)

### DIFF
--- a/Popper.js
+++ b/Popper.js
@@ -1,0 +1,29 @@
+```javascript
+import { createPopper } from '@popperjs/core'
+
+export function initPopper(referenceEl, popperEl) {
+  return createPopper(referenceEl, popperEl, {
+    placement: 'bottom',
+    modifiers: [
+      {
+        name: 'offset',
+        options: {
+          offset: [0, 4]
+        }
+      },
+      {
+        name: 'preventOverflow',
+        options: {
+          padding: 8
+        }
+      },
+      {
+        name: 'flip',
+        options: {
+          fallbackPlacements: ['top', 'right', 'left']
+        }
+      }
+    ]
+  })
+}
+```

--- a/TaskItem.vue
+++ b/TaskItem.vue
@@ -1,0 +1,97 @@
+```vue
+<template>
+  <div
+    class="task-wrapper"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+  >
+    <!-- Основная строка задачи -->
+    <div class="task-row">
+      <slot name="default" :task="task" />
+    </div>
+
+    <!-- Карточка подсказки -->
+    <HoverCard
+      v-if="isHover"
+      :task="task"
+      @mouseenter="clearLeaveTimer"
+      @mouseleave="scheduleLeave"
+    />
+  </div>
+</template>
+
+<script setup>
+import { ref, onBeforeUnmount } from 'vue';
+import HoverCard from '@/components/HoverCard.vue';
+
+defineProps({
+  task: {
+    type: Object,
+    required: true,
+  },
+});
+
+const isHover = ref(false);
+let enterTimer = null;
+let leaveTimer = null;
+const ENTER_DELAY = 100;
+const LEAVE_DELAY = 100;
+
+function clearEnterTimer() {
+  if (enterTimer) {
+    clearTimeout(enterTimer);
+    enterTimer = null;
+  }
+}
+
+function clearLeaveTimer() {
+  if (leaveTimer) {
+    clearTimeout(leaveTimer);
+    leaveTimer = null;
+  }
+}
+
+function handleMouseEnter() {
+  clearLeaveTimer();
+  clearEnterTimer();
+  enterTimer = setTimeout(() => {
+    isHover.value = true;
+    enterTimer = null;
+  }, ENTER_DELAY);
+}
+
+function scheduleLeave() {
+  clearEnterTimer();
+  clearLeaveTimer();
+  leaveTimer = setTimeout(() => {
+    isHover.value = false;
+    leaveTimer = null;
+  }, LEAVE_DELAY);
+}
+
+function handleMouseLeave() {
+  scheduleLeave();
+}
+
+onBeforeUnmount(() => {
+  clearEnterTimer();
+  clearLeaveTimer();
+});
+</script>
+
+<style scoped>
+.task-wrapper {
+  position: relative;
+  /* гарантируем, что карточка будет над строками списка */
+  z-index: 10;
+}
+
+/* Если в проекте используется глобальная стилизация строки,
+   здесь можно добавить дополнительные отступы, чтобы
+   курсор мог «перепрыгнуть» в карточку без перехода
+   на соседний элемент. */
+.task-row {
+  pointer-events: auto;
+}
+</style>
+```

--- a/TaskRow.vue
+++ b/TaskRow.vue
@@ -1,0 +1,107 @@
+```vue
+<template>
+  <div class="task-wrapper" @mouseenter="handleEnter" @mouseleave="handleLeave">
+    <!-- строка задачи -->
+    <div class="task-row" ref="reference">
+      <slot />
+    </div>
+
+    <!-- всплывающая подсказка -->
+    <HoverCard
+      v-show="isHover"
+      ref="cardEl"
+      @mouseenter="clearLeaveTimer"
+      @mouseleave="scheduleLeave"
+    />
+  </div>
+</template>
+
+<script>
+import { ref, nextTick, onBeforeUnmount } from 'vue';
+import { createPopper } from '@popperjs/core';
+import HoverCard from './HoverCard.vue';
+import popperConfig from '@/utils/popperConfig';
+
+export default {
+  name: 'TaskRow',
+  components: { HoverCard },
+
+  setup() {
+    const isHover = ref(false);
+    const reference = ref(null);
+    const cardEl = ref(null);
+    const popperInstance = ref(null);
+    const enterTimer = ref(null);
+    const leaveTimer = ref(null);
+
+    const scheduleEnter = () => {
+      clearTimeout(enterTimer.value);
+      enterTimer.value = setTimeout(() => {
+        isHover.value = true;
+        nextTick(() => {
+          if (reference.value && cardEl.value) {
+            popperInstance.value = createPopper(
+              reference.value,
+              cardEl.value,
+              popperConfig
+            );
+          }
+        });
+      }, 100);
+    };
+
+    const scheduleLeave = () => {
+      clearTimeout(leaveTimer.value);
+      leaveTimer.value = setTimeout(() => {
+        isHover.value = false;
+        if (popperInstance.value) {
+          popperInstance.value.destroy();
+          popperInstance.value = null;
+        }
+      }, 100);
+    };
+
+    const handleEnter = () => {
+      clearTimeout(leaveTimer.value);
+      scheduleEnter();
+    };
+
+    const handleLeave = () => {
+      clearTimeout(enterTimer.value);
+      scheduleLeave();
+    };
+
+    const clearLeaveTimer = () => {
+      clearTimeout(leaveTimer.value);
+    };
+
+    onBeforeUnmount(() => {
+      clearTimeout(enterTimer.value);
+      clearTimeout(leaveTimer.value);
+      if (popperInstance.value) {
+        popperInstance.value.destroy();
+      }
+    });
+
+    return {
+      isHover,
+      reference,
+      cardEl,
+      handleEnter,
+      handleLeave,
+      clearLeaveTimer,
+      scheduleLeave,
+    };
+  },
+};
+</script>
+
+<style scoped>
+.task-wrapper {
+  position: relative;
+}
+.task-row {
+  /* стили строки задачи (оставлены из оригинального кода) */
+}
+</style>
+```

--- a/e2e/specs/hover-card.spec.js
+++ b/e2e/specs/hover-card.spec.js
@@ -1,0 +1,41 @@
+```javascript
+// e2e/specs/hover-card.spec.js
+
+describe('Hover Card behavior', () => {
+  beforeEach(() => {
+    // Adjust the URL to match the page where the task list is rendered
+    cy.visit('/');
+  });
+
+  it('stays visible when moving cursor from task row to the hover card', () => {
+    // Hover over the first task row
+    cy.get('[data-cy=task-row]').first().trigger('mouseenter');
+
+    // Hover card should appear
+    cy.get('[data-cy=hover-card]').should('be.visible');
+
+    // Move cursor onto the hover card itself
+    cy.get('[data-cy=hover-card]').trigger('mouseenter');
+
+    // Small wait to let any timers settle
+    cy.wait(150);
+
+    // Hover card must still be visible
+    cy.get('[data-cy=hover-card]').should('be.visible');
+
+    // Leave the task row but keep the cursor on the hover card
+    cy.get('[data-cy=task-row]').first().trigger('mouseleave');
+
+    // Ensure the card remains visible after the row's mouseleave
+    cy.wait(150);
+    cy.get('[data-cy=hover-card]').should('be.visible');
+
+    // Finally, move the cursor away from the hover card
+    cy.get('[data-cy=hover-card]').trigger('mouseleave');
+
+    // Card should disappear after the hide delay
+    cy.wait(300);
+    cy.get('[data-cy=hover-card]').should('not.exist');
+  });
+});
+```

--- a/src/assets/styles/task.scss
+++ b/src/assets/styles/task.scss
@@ -1,0 +1,60 @@
+```scss
+/* src/assets/styles/task.scss */
+
+.task-wrapper {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  /* Ensure the wrapper captures hover events */
+  pointer-events: auto;
+}
+
+.task-row {
+  flex: 1 1 auto;
+  padding: 8px 12px;
+  background-color: var(--task-bg, #fff);
+  border-bottom: 1px solid var(--border-color, #e0e0e0);
+  cursor: pointer;
+  transition: background-color 0.15s ease-in-out;
+
+  &:hover,
+  .task-wrapper.is-hover & {
+    background-color: var(--task-hover-bg, #f5f7fa);
+  }
+}
+
+/* Hover card (popper) */
+.hover-card {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  min-width: 260px;
+  margin-top: 4px; /* offset from the task row */
+  padding: 12px;
+  background-color: var(--card-bg, #fff);
+  border: 1px solid var(--card-border, #dcdcdc);
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+  z-index: 10; /* above the task list */
+  pointer-events: auto; /* allow interaction */
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.12s ease-in-out, visibility 0.12s ease-in-out;
+
+  &.is-visible {
+    opacity: 1;
+    visibility: visible;
+  }
+}
+
+/* Prevent the next task row from being hovered while the card is open */
+.task-wrapper.is-hover + .task-row {
+  pointer-events: none;
+}
+
+/* Compact view adjustments */
+.compact .task-row {
+  padding: 4px 8px;
+  font-size: 0.875rem;
+}
+```

--- a/src/components/HoverCard.vue
+++ b/src/components/HoverCard.vue
@@ -1,0 +1,45 @@
+```vue
+<template>
+  <div
+    class="hover-card"
+    v-show="visible"
+    @mouseenter="onMouseEnter"
+    @mouseleave="onMouseLeave"
+  >
+    <slot />
+  </div>
+</template>
+
+<script setup>
+import { defineProps, defineEmits } from 'vue'
+
+const props = defineProps({
+  visible: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const emit = defineEmits(['mouseenter', 'mouseleave'])
+
+function onMouseEnter() {
+  emit('mouseenter')
+}
+
+function onMouseLeave() {
+  emit('mouseleave')
+}
+</script>
+
+<style scoped>
+.hover-card {
+  position: absolute;
+  background: var(--card-bg, #fff);
+  border: 1px solid var(--card-border, #e0e0e0);
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  pointer-events: auto;
+  z-index: 10;
+}
+</style>
+```

--- a/src/components/TaskItem.vue
+++ b/src/components/TaskItem.vue
@@ -1,0 +1,137 @@
+```vue
+<template>
+  <div
+    class="task-wrapper"
+    @mouseenter="onEnter"
+    @mouseleave="onLeave"
+    ref="wrapperRef"
+  >
+    <div class="task-row" ref="taskRef">
+      <!-- original task row content -->
+      <slot />
+    </div>
+
+    <HoverCard
+      v-if="hoverVisible"
+      :reference-element="taskRef"
+      :visible="isHover"
+      @mouseenter="clearLeaveTimer"
+      @mouseleave="scheduleLeave"
+      ref="cardRef"
+    />
+  </div>
+</template>
+
+<script>
+import { ref, watch, onBeforeUnmount } from 'vue';
+import { createPopper } from '@popperjs/core';
+import HoverCard from './HoverCard.vue';
+
+export default {
+  name: 'TaskItem',
+  components: { HoverCard },
+  setup() {
+    const isHover = ref(false);
+    const enterTimer = ref(null);
+    const leaveTimer = ref(null);
+    const wrapperRef = ref(null);
+    const taskRef = ref(null);
+    const cardRef = ref(null);
+    let popperInstance = null;
+
+    const onEnter = () => {
+      clearTimeout(leaveTimer.value);
+      if (!enterTimer.value) {
+        enterTimer.value = setTimeout(() => {
+          isHover.value = true;
+          enterTimer.value = null;
+        }, 100);
+      }
+    };
+
+    const onLeave = () => {
+      clearTimeout(enterTimer.value);
+      scheduleLeave();
+    };
+
+    const clearLeaveTimer = () => {
+      clearTimeout(leaveTimer.value);
+    };
+
+    const scheduleLeave = () => {
+      if (!leaveTimer.value) {
+        leaveTimer.value = setTimeout(() => {
+          isHover.value = false;
+          leaveTimer.value = null;
+        }, 100);
+      }
+    };
+
+    const initPopper = () => {
+      if (taskRef.value && cardRef.value) {
+        popperInstance = createPopper(taskRef.value, cardRef.value.$el, {
+          placement: 'bottom',
+          modifiers: [
+            {
+              name: 'offset',
+              options: { offset: [0, 4] },
+            },
+            {
+              name: 'preventOverflow',
+              options: { padding: 8 },
+            },
+            {
+              name: 'flip',
+              options: { fallbackPlacements: ['top', 'right', 'left'] },
+            },
+          ],
+        });
+      }
+    };
+
+    const destroyPopper = () => {
+      if (popperInstance) {
+        popperInstance.destroy();
+        popperInstance = null;
+      }
+    };
+
+    watch(isHover, (newVal) => {
+      if (newVal) {
+        initPopper();
+      } else {
+        destroyPopper();
+      }
+    });
+
+    onBeforeUnmount(() => {
+      clearTimeout(enterTimer.value);
+      clearTimeout(leaveTimer.value);
+      destroyPopper();
+    });
+
+    return {
+      wrapperRef,
+      taskRef,
+      cardRef,
+      isHover,
+      hoverVisible: isHover,
+      onEnter,
+      onLeave,
+      clearLeaveTimer,
+      scheduleLeave,
+    };
+  },
+};
+</script>
+
+<style scoped>
+.task-wrapper {
+  position: relative;
+  z-index: 10;
+}
+.task-row {
+  /* existing row styles */
+}
+</style>
+```

--- a/src/utils/popperConfig.js
+++ b/src/utils/popperConfig.js
@@ -1,0 +1,29 @@
+```js
+import { offset, flip, preventOverflow } from '@popperjs/core'
+
+export default function getPopperConfig () {
+  return {
+    placement: 'bottom',
+    modifiers: [
+      {
+        name: 'offset',
+        options: {
+          offset: [0, 4]
+        }
+      },
+      {
+        name: 'preventOverflow',
+        options: {
+          padding: 8
+        }
+      },
+      {
+        name: 'flip',
+        options: {
+          fallbackPlacements: ['top', 'right', 'left']
+        }
+      }
+    ]
+  }
+}
+```

--- a/task.scss
+++ b/task.scss
@@ -1,0 +1,30 @@
+.task-wrapper {
+  position: relative;
+  z-index: 1;
+}
+
+.task-row {
+  cursor: pointer;
+  /* existing styles may be here */
+}
+
+.hover-card {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  margin-top: 4px;
+  pointer-events: auto;
+  z-index: 10;
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  padding: 8px;
+  min-width: 200px;
+  /* existing styles may be here */
+}
+
+/* optional hidden state */
+.hover-card--hidden {
+  display: none;
+}

--- a/tests/unit/TaskItem.spec.js
+++ b/tests/unit/TaskItem.spec.js
@@ -1,0 +1,53 @@
+```js
+import { mount } from '@vue/test-utils'
+import TaskItem from '@/components/TaskItem.vue'
+
+describe('TaskItem – hover card behavior', () => {
+  beforeAll(() => {
+    // make sure popper elements are attached to the DOM
+    const container = document.createElement('div')
+    container.id = 'app'
+    document.body.appendChild(container)
+  })
+
+  afterAll(() => {
+    const app = document.getElementById('app')
+    if (app) {
+      app.remove()
+    }
+  })
+
+  it('keeps the HoverCard visible when cursor moves from the row to the card', async () => {
+    const wrapper = mount(TaskItem, {
+      attachTo: '#app',
+    })
+
+    const row = wrapper.find('.task-row')
+    await row.trigger('mouseenter')
+    await wrapper.vm.$nextTick()
+
+    // HoverCard should appear
+    const hoverCard = () => wrapper.findComponent({ name: 'HoverCard' })
+    expect(hoverCard().exists()).toBe(true)
+
+    // Simulate moving cursor onto the card
+    await hoverCard().trigger('mouseenter')
+    await wrapper.vm.$nextTick()
+
+    // Leave the row – card must stay open because cursor is on it
+    await row.trigger('mouseleave')
+    await wrapper.vm.$nextTick()
+
+    // wait for the hide‑delay defined in the component (≈100 ms)
+    await new Promise((r) => setTimeout(r, 200))
+    expect(hoverCard().exists()).toBe(true)
+
+    // Finally leave the card itself – it should disappear
+    await hoverCard().trigger('mouseleave')
+    await new Promise((r) => setTimeout(r, 200))
+    expect(hoverCard().exists()).toBe(false)
+
+    wrapper.unmount()
+  })
+})
+```


### PR DESCRIPTION
Closes #1

## Plan
**Краткий план исправления «исчезающей» карточки‑подсказки**

| № | Что делаем | Где правим |
|---|------------|------------|
| 1 | **Объединяем зоны наведения** – вынести `task‑row` и `hover‑card` в один общий контейнер, чтобы `mouseenter`/`mouseleave` отслеживались на уровне контейнера, а не только на строке задачи. | `src/components/TaskItem.vue` (или `TaskRow.vue`) – добавить обёртку `<div class="task-wrapper" @mouseenter="onEnter" @mouseleave="onLeave">…</div>` и перенести туда `HoverCard` |
| 2 | **Передаём состояние «открыто» в `HoverCard`** – вместо того, чтобы карточка открывалась/закрывалась по `mouseleave` строки, управлять её видимостью через реактивный `isHover` в родителе. | `src/components/TaskItem.vue` – добавить `data() { return { isHover: false } }` и методы `onEnter/ onLeave` (с небольшим `setTimeout` ≈ 100 ms, чтобы избежать «мигания»). |
| 3 | **Добавляем обработчики наведения на самой карточке** – чтобы при перемещении курсора из строки в карточку `mouseleave` у контейнера не срабатывал сразу, а «запоминал», что курсор всё ещё внутри дочернего элемента. | `src/components/HoverCard.vue` – `@mouseenter="clearLeaveTimer"` и `@mouseleave="scheduleLeave"` (использовать те же таймеры, что в родителе). |
| 4 | **Корректируем позиционирование Popper.js** – при открытии карточки снизу добавить `modifiers: [{ name: 'offset', options: { offset: [0, 4] } }]` и `preventOverflow` → `padding: 8` чтобы карточка не «перекрывала» следующую строку. | `src/utils/popperConfig.js` (если есть) или непосредственно в `TaskItem.vue` при вызове `createPopper`. |
| 5 | **CSS‑правка: `pointer-events`** – убедиться, что у карточки `pointer-events: auto;` (а у строки, если используется `pointer-events: none` в некоторых состояниях, убрать). Также задать небольшое `z-index` > записей списка, чтобы при наведении курсор «перепрыгивал» в карточку, а не в следующую строку. | `src/assets/styles/task.scss` (или `TaskItem.vue`‑style block). |
| 6 | **Тестируем в разных сценариях** – вертикальный скролл, ограниченное пространство (карточка выше/ниже), разные масштабы браузера, Compact‑view. Убедиться, что при переходе курсора из строки в карточку карточка остаётся видимой и реагирует на клики. | Нет новых файлов, только ручное тестирование/`npm run serve`. |
| 7 | **Пишем unit‑/e2e‑тест** (если в проекте есть тесты) – имитировать `mouseenter`/`mouseleave` и проверять, что `HoverCard` остаётся в DOM после перемещения курсора вниз. | `tests/unit/TaskItem.spec.js` (или `e2e/specs/hover-card.spec.js`). |

---

### Какие файлы необходимо изменить

| Файл | Задача |
|------|--------|
| `src/components/TaskItem.vue` (или `TaskRow.vue`) | Добавить обёртку‑контейнер, управлять состоянием `isHover`, импортировать и разместить `<HoverCard :visible="isHover" …/>`, внедрить таймеры `enterTimer/leaveTimer`. |
| `src/components/HoverCard.vue` | Добавить `@mouseenter` / `@mouseleave`‑слушатели, которые вызывают методы родителя через `emit` или используют переданные колбэки, обеспечить `pointer-events: auto`. |
| `src/utils/popperConfig.js` (если существует) **или** блок `setup()` в `TaskItem.vue` | Настроить Popper‑модификаторы (`offset`, `preventOverflow`, `flip`) так, чтобы карточка всегда «прилипала» к задаче и не перекрывала следующую строку. |
| `src/assets/styles/*.scss` (например `task.scss` или стиль внутри `TaskItem.vue`) | Установить `z-index` > записей списка, `pointer-events` и небольшие отступы, чтобы курсор мог «перепрыгнуть» в карточку без активации следующей строки. |
| `tests/unit/TaskItem.spec.js` (опционально) | Добавить тест, проверяющий, что при `mouseenter` на задачу и последующем движении к карточке она остаётся открытой. |

---

**Итого:** Переносим логику показа карточки из «hover‑row» в общий контейнер, синхронно отслеживаем наведение как на строке, так и на самой карточке, добавляем небольшую задержку перед скрытием и корректируем позиционирование/стили, чтобы курсор не «перепрыгивал» на соседнюю задачу. После этих правок карточка будет оставаться видимой и интерактивной независимо от того, находится она выше или ниже задачи.