### PR TITLE
[Agent] Fix: UX bug : Task hover card disappears when moving mouse into it (only when displayed below task)

### DIFF
--- a/HoverCard.vue
+++ b/HoverCard.vue
@@ -3,7 +3,6 @@
   <div
     ref="popperEl"
     class="hover-card"
-    :class="{ 'is-visible': true }"
     @mouseenter="onCardEnter"
     @mouseleave="onCardLeave"
   >
@@ -17,7 +16,7 @@ import { createPopper, type Instance as PopperInstance } from '@popperjs/core'
 
 const props = defineProps<{
   /** Element that triggers the hover card (the task row) */
-  referenceEl: HTMLElement
+  reference: HTMLElement
 }>()
 
 const emit = defineEmits<{
@@ -29,39 +28,25 @@ const popperEl = ref<HTMLElement | null>(null)
 let popperInstance: PopperInstance | null = null
 
 const initPopper = () => {
-  if (props.referenceEl && popperEl.value) {
-    popperInstance = createPopper(props.referenceEl, popperEl.value, {
+  if (props.reference && popperEl.value) {
+    popperInstance = createPopper(props.reference, popperEl.value, {
       placement: 'bottom',
       modifiers: [
-        {
-          name: 'offset',
-          options: { offset: [0, 8] },
-        },
-        {
-          name: 'preventOverflow',
-          options: { boundary: 'clippingParents' },
-        },
-        {
-          name: 'flip',
-          options: { fallbackPlacements: ['top'] },
-        },
+        { name: 'offset', options: { offset: [0, 8] } },
+        { name: 'preventOverflow', options: { boundary: 'clippingParents' } },
+        { name: 'flip', options: { fallbackPlacements: ['top'] } },
       ],
     })
   }
 }
 
 const destroyPopper = () => {
-  if (popperInstance) {
-    popperInstance.destroy()
-    popperInstance = null
-  }
+  popperInstance?.destroy()
+  popperInstance = null
 }
 
-const onCardEnter = () => emit('card-enter')
-const onCardLeave = () => emit('card-leave')
-
 watch(
-  () => props.referenceEl,
+  () => props.reference,
   () => {
     destroyPopper()
     initPopper()
@@ -70,6 +55,9 @@ watch(
 
 onMounted(initPopper)
 onBeforeUnmount(destroyPopper)
+
+const onCardEnter = () => emit('card-enter')
+const onCardLeave = () => emit('card-leave')
 </script>
 
 <style scoped>
@@ -81,8 +69,6 @@ onBeforeUnmount(destroyPopper)
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   border-radius: 4px;
   padding: 0.75rem;
-}
-.is-visible {
   opacity: 1;
   transition: opacity 0.15s ease-in-out;
 }

--- a/HoverCard.vue
+++ b/HoverCard.vue
@@ -1,0 +1,98 @@
+```vue
+<template>
+  <div
+    ref="popperEl"
+    class="hover-card"
+    @mouseenter="onCardEnter"
+    @mouseleave="onCardLeave"
+  >
+    <slot />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, onMounted, onBeforeUnmount } from 'vue'
+import { createPopper, type Instance as PopperInstance } from '@popperjs/core'
+
+const props = defineProps<{
+  /** Element that triggers the hover card (the task row) */
+  referenceEl: HTMLElement
+  /** Controls visibility – parent toggles via v-if */
+  /** (kept for type completeness, not used directly) */
+}>()
+
+const emit = defineEmits<{
+  (e: 'card-enter'): void
+  (e: 'card-leave'): void
+}>()
+
+const popperEl = ref<HTMLElement | null>(null)
+let popperInstance: PopperInstance | null = null
+
+const initPopper = () => {
+  if (props.referenceEl && popperEl.value) {
+    popperInstance = createPopper(props.referenceEl, popperEl.value, {
+      placement: 'bottom',
+      modifiers: [
+        {
+          name: 'offset',
+          options: {
+            offset: [0, 8],
+          },
+        },
+        {
+          name: 'preventOverflow',
+          options: {
+            boundary: 'clippingParents',
+          },
+        },
+      ],
+    })
+  }
+}
+
+const destroyPopper = () => {
+  if (popperInstance) {
+    popperInstance.destroy()
+    popperInstance = null
+  }
+}
+
+const onCardEnter = () => {
+  emit('card-enter')
+}
+
+const onCardLeave = () => {
+  emit('card-leave')
+}
+
+/* Re‑initialize popper if the reference element changes */
+watch(
+  () => props.referenceEl,
+  () => {
+    destroyPopper()
+    initPopper()
+  },
+)
+
+onMounted(() => {
+  initPopper()
+})
+
+onBeforeUnmount(() => {
+  destroyPopper()
+})
+</script>
+
+<style scoped>
+.hover-card {
+  position: absolute;
+  pointer-events: auto;
+  z-index: 1000;
+  background: var(--card-bg, #fff);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  border-radius: 4px;
+  padding: 0.75rem;
+}
+</style>
+```

--- a/HoverCard.vue
+++ b/HoverCard.vue
@@ -11,12 +11,11 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, onMounted, onBeforeUnmount } from 'vue'
-import { createPopper, type Instance as PopperInstance } from '@popperjs/core'
+defineOptions({ name: 'HoverCard' })
 
 const props = defineProps<{
   /** Element that triggers the hover card (the task row) */
-  reference: HTMLElement
+  referenceEl: HTMLElement | null
 }>()
 
 const emit = defineEmits<{
@@ -25,11 +24,11 @@ const emit = defineEmits<{
 }>()
 
 const popperEl = ref<HTMLElement | null>(null)
-let popperInstance: PopperInstance | null = null
+let popperInstance: Instance | null = null
 
 const initPopper = () => {
-  if (props.reference && popperEl.value) {
-    popperInstance = createPopper(props.reference, popperEl.value, {
+  if (props.referenceEl && popperEl.value) {
+    popperInstance = createPopper(props.referenceEl, popperEl.value, {
       placement: 'bottom',
       modifiers: [
         { name: 'offset', options: { offset: [0, 8] } },
@@ -46,7 +45,7 @@ const destroyPopper = () => {
 }
 
 watch(
-  () => props.reference,
+  () => props.referenceEl,
   () => {
     destroyPopper()
     initPopper()

--- a/HoverCard.vue
+++ b/HoverCard.vue
@@ -3,6 +3,7 @@
   <div
     ref="popperEl"
     class="hover-card"
+    :class="{ 'is-visible': true }"
     @mouseenter="onCardEnter"
     @mouseleave="onCardLeave"
   >
@@ -17,8 +18,6 @@ import { createPopper, type Instance as PopperInstance } from '@popperjs/core'
 const props = defineProps<{
   /** Element that triggers the hover card (the task row) */
   referenceEl: HTMLElement
-  /** Controls visibility – parent toggles via v-if */
-  /** (kept for type completeness, not used directly) */
 }>()
 
 const emit = defineEmits<{
@@ -36,15 +35,15 @@ const initPopper = () => {
       modifiers: [
         {
           name: 'offset',
-          options: {
-            offset: [0, 8],
-          },
+          options: { offset: [0, 8] },
         },
         {
           name: 'preventOverflow',
-          options: {
-            boundary: 'clippingParents',
-          },
+          options: { boundary: 'clippingParents' },
+        },
+        {
+          name: 'flip',
+          options: { fallbackPlacements: ['top'] },
         },
       ],
     })
@@ -58,15 +57,9 @@ const destroyPopper = () => {
   }
 }
 
-const onCardEnter = () => {
-  emit('card-enter')
-}
+const onCardEnter = () => emit('card-enter')
+const onCardLeave = () => emit('card-leave')
 
-const onCardLeave = () => {
-  emit('card-leave')
-}
-
-/* Re‑initialize popper if the reference element changes */
 watch(
   () => props.referenceEl,
   () => {
@@ -75,13 +68,8 @@ watch(
   },
 )
 
-onMounted(() => {
-  initPopper()
-})
-
-onBeforeUnmount(() => {
-  destroyPopper()
-})
+onMounted(initPopper)
+onBeforeUnmount(destroyPopper)
 </script>
 
 <style scoped>
@@ -93,6 +81,10 @@ onBeforeUnmount(() => {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   border-radius: 4px;
   padding: 0.75rem;
+}
+.is-visible {
+  opacity: 1;
+  transition: opacity 0.15s ease-in-out;
 }
 </style>
 ```

--- a/TaskItem.vue
+++ b/TaskItem.vue
@@ -6,10 +6,8 @@
     @mouseenter="onMouseEnter"
     @mouseleave="onMouseLeave"
   >
-    <!-- Содержимое задачи (может быть слотом или прямым выводом) -->
     <slot />
 
-    <!-- Hover‑card, отображается внутри задачи -->
     <HoverCard
       v-if="showHover"
       :task="task"

--- a/TaskItem.vue
+++ b/TaskItem.vue
@@ -11,6 +11,7 @@
     <HoverCard
       v-if="showHover"
       :task="task"
+      :reference-el="taskRef"
       @card-enter="onCardEnter"
       @card-leave="onCardLeave"
     />

--- a/TaskItem.vue
+++ b/TaskItem.vue
@@ -30,21 +30,21 @@ const props = defineProps({
 });
 
 const showHover = ref(false);
-const hideTimeout = ref(null);
+let hideTimeout = null;
 const taskRef = ref(null);
 
 function clearHide() {
-  if (hideTimeout.value) {
-    clearTimeout(hideTimeout.value);
-    hideTimeout.value = null;
+  if (hideTimeout !== null) {
+    clearTimeout(hideTimeout);
+    hideTimeout = null;
   }
 }
 
 function scheduleHide() {
   clearHide();
-  hideTimeout.value = setTimeout(() => {
+  hideTimeout = setTimeout(() => {
     showHover.value = false;
-    hideTimeout.value = null;
+    hideTimeout = null;
   }, 200);
 }
 

--- a/TaskItem.vue
+++ b/TaskItem.vue
@@ -1,0 +1,79 @@
+```vue
+<template>
+  <div
+    class="task-item"
+    ref="taskRef"
+    @mouseenter="onMouseEnter"
+    @mouseleave="onMouseLeave"
+  >
+    <!-- Содержимое задачи (может быть слотом или прямым выводом) -->
+    <slot />
+
+    <!-- Hover‑card, отображается внутри задачи -->
+    <HoverCard
+      v-if="showHover"
+      :task="task"
+      @card-enter="onCardEnter"
+      @card-leave="onCardLeave"
+    />
+  </div>
+</template>
+
+<script setup>
+import { ref, onBeforeUnmount } from 'vue';
+import HoverCard from './HoverCard.vue';
+
+const props = defineProps({
+  task: {
+    type: Object,
+    required: true,
+  },
+});
+
+const showHover = ref(false);
+const hideTimeout = ref(null);
+const taskRef = ref(null);
+
+function clearHide() {
+  if (hideTimeout.value) {
+    clearTimeout(hideTimeout.value);
+    hideTimeout.value = null;
+  }
+}
+
+function scheduleHide() {
+  clearHide();
+  hideTimeout.value = setTimeout(() => {
+    showHover.value = false;
+    hideTimeout.value = null;
+  }, 200);
+}
+
+function onMouseEnter() {
+  clearHide();
+  showHover.value = true;
+}
+
+function onMouseLeave() {
+  scheduleHide();
+}
+
+function onCardEnter() {
+  clearHide();
+}
+
+function onCardLeave() {
+  scheduleHide();
+}
+
+onBeforeUnmount(() => {
+  clearHide();
+});
+</script>
+
+<style scoped>
+.task-item {
+  position: relative;
+}
+</style>
+```

--- a/src/assets/styles/_hover-card.scss
+++ b/src/assets/styles/_hover-card.scss
@@ -13,18 +13,18 @@
   border-radius: var(--border-radius, 4px);
   box-shadow: var(--hover-card-shadow, 0 2px 8px rgba(0, 0, 0, 0.15));
   z-index: 1000;
-  pointer-events: auto;
+  pointer-events: none;
   visibility: hidden;
   opacity: 0;
   transition: opacity 0.15s ease, visibility 0.15s ease;
 
-  /* Visible state – component adds the `is-visible` class */
-  &.is-visible {
+  &.is-visible,
+  &.visible {
     visibility: visible;
     opacity: 1;
+    pointer-events: auto;
   }
 
-  /* Placement modifiers – used by Popper via `data-popper-placement` */
   &[data-popper-placement^='top'] {
     top: auto;
     bottom: 100%;
@@ -37,7 +37,6 @@
     top: 0;
     margin-top: 0;
     margin-left: 4px;
-    margin-right: 0;
   }
 
   &[data-popper-placement^='left'] {
@@ -45,7 +44,6 @@
     top: 0;
     margin-top: 0;
     margin-right: 4px;
-    margin-left: 0;
   }
 }
 ```

--- a/src/assets/styles/_hover-card.scss
+++ b/src/assets/styles/_hover-card.scss
@@ -18,9 +18,34 @@
   opacity: 0;
   transition: opacity 0.15s ease, visibility 0.15s ease;
 
+  /* Visible state – component adds the `is-visible` class */
   &.is-visible {
     visibility: visible;
     opacity: 1;
+  }
+
+  /* Placement modifiers – used by Popper via `data-popper-placement` */
+  &[data-popper-placement^='top'] {
+    top: auto;
+    bottom: 100%;
+    margin-top: 0;
+    margin-bottom: 4px;
+  }
+
+  &[data-popper-placement^='right'] {
+    left: 100%;
+    top: 0;
+    margin-top: 0;
+    margin-left: 4px;
+    margin-right: 0;
+  }
+
+  &[data-popper-placement^='left'] {
+    right: 100%;
+    top: 0;
+    margin-top: 0;
+    margin-right: 4px;
+    margin-left: 0;
   }
 }
 ```

--- a/src/assets/styles/_hover-card.scss
+++ b/src/assets/styles/_hover-card.scss
@@ -25,21 +25,21 @@
     pointer-events: auto;
   }
 
-  &[data-popper-placement^='top'] {
+  &[data-popper-placement^="top"] {
     top: auto;
     bottom: 100%;
     margin-top: 0;
     margin-bottom: 4px;
   }
 
-  &[data-popper-placement^='right'] {
+  &[data-popper-placement^="right"] {
     left: 100%;
     top: 0;
     margin-top: 0;
     margin-left: 4px;
   }
 
-  &[data-popper-placement^='left'] {
+  &[data-popper-placement^="left"] {
     right: 100%;
     top: 0;
     margin-top: 0;

--- a/src/assets/styles/_hover-card.scss
+++ b/src/assets/styles/_hover-card.scss
@@ -1,0 +1,26 @@
+```scss
+/* src/assets/styles/_hover-card.scss */
+
+.hover-card {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  min-width: 200px;
+  margin-top: 4px;
+  padding: 0.5rem 0.75rem;
+  background: var(--hover-card-bg, #fff);
+  border: 1px solid var(--hover-card-border, #e0e0e0);
+  border-radius: var(--border-radius, 4px);
+  box-shadow: var(--hover-card-shadow, 0 2px 8px rgba(0, 0, 0, 0.15));
+  z-index: 1000;
+  pointer-events: auto;
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 0.15s ease, visibility 0.15s ease;
+
+  &.is-visible {
+    visibility: visible;
+    opacity: 1;
+  }
+}
+```

--- a/src/components/HoverCard.vue
+++ b/src/components/HoverCard.vue
@@ -3,6 +3,7 @@
   <div
     ref="cardRef"
     class="hover-card"
+    :class="{ 'is-visible': visible }"
     @mouseenter="onCardEnter"
     @mouseleave="onCardLeave"
   >
@@ -12,13 +13,15 @@
 
 <script setup lang="ts">
 import { ref, onMounted, onBeforeUnmount, watch, defineEmits, defineProps } from 'vue'
-import { createPopper, Instance as PopperInstance, Placement } from '@popperjs/core'
+import { createPopper, type Instance as PopperInstance, type Placement } from '@popperjs/core'
 
 const props = defineProps<{
   /** Element that triggers the hover card (the task row) */
-  referenceEl: HTMLElement | null
+  reference: HTMLElement | null
   /** Preferred placement – defaults to 'bottom' */
   placement?: Placement
+  /** Control visibility of the card */
+  visible?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -30,12 +33,13 @@ const cardRef = ref<HTMLElement | null>(null)
 let popperInstance: PopperInstance | null = null
 
 const initPopper = () => {
-  if (props.referenceEl && cardRef.value) {
-    popperInstance = createPopper(props.referenceEl, cardRef.value, {
+  if (props.reference && cardRef.value) {
+    popperInstance = createPopper(props.reference, cardRef.value, {
       placement: props.placement ?? 'bottom',
       modifiers: [
         { name: 'offset', options: { offset: [0, 8] } },
         { name: 'preventOverflow', options: { padding: 8 } },
+        { name: 'flip', options: { fallbackPlacements: ['top', 'right', 'left'] } },
       ],
     })
   }
@@ -48,9 +52,9 @@ const destroyPopper = () => {
   }
 }
 
-/* Re‑init popper when reference element becomes available */
+/* Re‑init popper when reference element changes */
 watch(
-  () => props.referenceEl,
+  () => props.reference,
   (newRef) => {
     destroyPopper()
     if (newRef) initPopper()
@@ -66,13 +70,8 @@ onBeforeUnmount(() => {
   destroyPopper()
 })
 
-const onCardEnter = () => {
-  emit('card-enter')
-}
-
-const onCardLeave = () => {
-  emit('card-leave')
-}
+const onCardEnter = () => emit('card-enter')
+const onCardLeave = () => emit('card-leave')
 </script>
 
 <style scoped>
@@ -84,6 +83,11 @@ const onCardLeave = () => {
   border-radius: 4px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
   padding: 12px;
+  opacity: 0;
+  transition: opacity 0.15s ease-in-out;
+}
+.hover-card.is-visible {
+  opacity: 1;
 }
 </style>
 ```

--- a/src/components/HoverCard.vue
+++ b/src/components/HoverCard.vue
@@ -12,12 +12,22 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount, watch, defineProps, defineEmits } from 'vue'
+import {
+  ref,
+  onMounted,
+  onBeforeUnmount,
+  watch,
+  defineProps,
+  defineEmits,
+  defineOptions,
+} from 'vue'
 import {
   createPopper,
   type Instance as PopperInstance,
   type Placement,
 } from '@popperjs/core'
+
+defineOptions({ name: 'HoverCard' })
 
 const props = defineProps<{
   /** Element that triggers the hover card (the task row) */

--- a/src/components/HoverCard.vue
+++ b/src/components/HoverCard.vue
@@ -12,12 +12,16 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount, watch, defineEmits, defineProps } from 'vue'
-import { createPopper, type Instance as PopperInstance, type Placement } from '@popperjs/core'
+import { ref, onMounted, onBeforeUnmount, watch, defineProps, defineEmits } from 'vue'
+import {
+  createPopper,
+  type Instance as PopperInstance,
+  type Placement,
+} from '@popperjs/core'
 
 const props = defineProps<{
   /** Element that triggers the hover card (the task row) */
-  reference: HTMLElement | null
+  referenceEl: HTMLElement | null
   /** Preferred placement – defaults to 'bottom' */
   placement?: Placement
   /** Control visibility of the card */
@@ -33,13 +37,16 @@ const cardRef = ref<HTMLElement | null>(null)
 let popperInstance: PopperInstance | null = null
 
 const initPopper = () => {
-  if (props.reference && cardRef.value) {
-    popperInstance = createPopper(props.reference, cardRef.value, {
+  if (props.referenceEl && cardRef.value) {
+    popperInstance = createPopper(props.referenceEl, cardRef.value, {
       placement: props.placement ?? 'bottom',
       modifiers: [
         { name: 'offset', options: { offset: [0, 8] } },
         { name: 'preventOverflow', options: { padding: 8 } },
-        { name: 'flip', options: { fallbackPlacements: ['top', 'right', 'left'] } },
+        {
+          name: 'flip',
+          options: { fallbackPlacements: ['top', 'right', 'left'] },
+        },
       ],
     })
   }
@@ -54,12 +61,12 @@ const destroyPopper = () => {
 
 /* Re‑init popper when reference element changes */
 watch(
-  () => props.reference,
+  () => props.referenceEl,
   (newRef) => {
     destroyPopper()
     if (newRef) initPopper()
   },
-  { immediate: true }
+  { immediate: true },
 )
 
 onMounted(() => {

--- a/src/components/HoverCard.vue
+++ b/src/components/HoverCard.vue
@@ -1,0 +1,89 @@
+```vue
+<template>
+  <div
+    ref="cardRef"
+    class="hover-card"
+    @mouseenter="onCardEnter"
+    @mouseleave="onCardLeave"
+  >
+    <slot />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, onBeforeUnmount, watch, defineEmits, defineProps } from 'vue'
+import { createPopper, Instance as PopperInstance, Placement } from '@popperjs/core'
+
+const props = defineProps<{
+  /** Element that triggers the hover card (the task row) */
+  referenceEl: HTMLElement | null
+  /** Preferred placement – defaults to 'bottom' */
+  placement?: Placement
+}>()
+
+const emit = defineEmits<{
+  (e: 'card-enter'): void
+  (e: 'card-leave'): void
+}>()
+
+const cardRef = ref<HTMLElement | null>(null)
+let popperInstance: PopperInstance | null = null
+
+const initPopper = () => {
+  if (props.referenceEl && cardRef.value) {
+    popperInstance = createPopper(props.referenceEl, cardRef.value, {
+      placement: props.placement ?? 'bottom',
+      modifiers: [
+        { name: 'offset', options: { offset: [0, 8] } },
+        { name: 'preventOverflow', options: { padding: 8 } },
+      ],
+    })
+  }
+}
+
+const destroyPopper = () => {
+  if (popperInstance) {
+    popperInstance.destroy()
+    popperInstance = null
+  }
+}
+
+/* Re‑init popper when reference element becomes available */
+watch(
+  () => props.referenceEl,
+  (newRef) => {
+    destroyPopper()
+    if (newRef) initPopper()
+  },
+  { immediate: true }
+)
+
+onMounted(() => {
+  initPopper()
+})
+
+onBeforeUnmount(() => {
+  destroyPopper()
+})
+
+const onCardEnter = () => {
+  emit('card-enter')
+}
+
+const onCardLeave = () => {
+  emit('card-leave')
+}
+</script>
+
+<style scoped>
+.hover-card {
+  position: absolute;
+  pointer-events: auto;
+  z-index: 1000;
+  background: var(--card-bg, #fff);
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  padding: 12px;
+}
+</style>
+```

--- a/src/components/TaskItem.vue
+++ b/src/components/TaskItem.vue
@@ -24,21 +24,21 @@ import { ref, onBeforeUnmount } from 'vue'
 import HoverCard from './HoverCard.vue'
 
 const showHover = ref(false)
-const hideTimeout = ref(null)
-const taskRef = ref(null)
+let hideTimeout: ReturnType<typeof setTimeout> | null = null
+const taskRef = ref<HTMLElement | null>(null)
 
 function clearHide() {
-  if (hideTimeout.value) {
-    clearTimeout(hideTimeout.value)
-    hideTimeout.value = null
+  if (hideTimeout) {
+    clearTimeout(hideTimeout)
+    hideTimeout = null
   }
 }
 
 function scheduleHide() {
   clearHide()
-  hideTimeout.value = setTimeout(() => {
+  hideTimeout = setTimeout(() => {
     showHover.value = false
-    hideTimeout.value = null
+    hideTimeout = null
   }, 200)
 }
 

--- a/src/components/TaskItem.vue
+++ b/src/components/TaskItem.vue
@@ -1,0 +1,56 @@
+<template>
+  <div class="task-item" @mouseenter="onMouseEnter" @mouseleave="onMouseLeave" ref="taskRef">
+    <div class="task-content">
+      <slot />
+    </div>
+    <HoverCard
+      v-if="showHover"
+      :reference="taskRef"
+      @card-enter="clearHide"
+      @card-leave="scheduleHide"
+    />
+  </div>
+</template>
+
+<script setup>
+import { ref, onBeforeUnmount } from 'vue'
+import HoverCard from './HoverCard.vue'
+
+const showHover = ref(false)
+const hideTimeout = ref(null)
+const taskRef = ref(null)
+
+function clearHide() {
+  if (hideTimeout.value) {
+    clearTimeout(hideTimeout.value)
+    hideTimeout.value = null
+  }
+}
+
+function scheduleHide() {
+  clearHide()
+  hideTimeout.value = setTimeout(() => {
+    showHover.value = false
+    hideTimeout.value = null
+  }, 200)
+}
+
+function onMouseEnter() {
+  clearHide()
+  showHover.value = true
+}
+
+function onMouseLeave() {
+  scheduleHide()
+}
+
+onBeforeUnmount(() => {
+  clearHide()
+})
+</script>
+
+<style scoped>
+.task-item {
+  position: relative;
+}
+</style>

--- a/src/components/TaskItem.vue
+++ b/src/components/TaskItem.vue
@@ -1,11 +1,18 @@
+```vue
 <template>
-  <div class="task-item" @mouseenter="onMouseEnter" @mouseleave="onMouseLeave" ref="taskRef">
+  <div
+    class="task-item"
+    @mouseenter="onMouseEnter"
+    @mouseleave="onMouseLeave"
+    ref="taskRef"
+  >
     <div class="task-content">
       <slot />
     </div>
+
     <HoverCard
       v-if="showHover"
-      :reference="taskRef"
+      :referenceEl="taskRef"
       @card-enter="clearHide"
       @card-leave="scheduleHide"
     />
@@ -54,3 +61,4 @@ onBeforeUnmount(() => {
   position: relative;
 }
 </style>
+```

--- a/src/components/TaskItem.vue
+++ b/src/components/TaskItem.vue
@@ -12,7 +12,7 @@
 
     <HoverCard
       v-if="showHover"
-      :referenceEl="taskRef"
+      :reference="taskRef"
       @card-enter="clearHide"
       @card-leave="scheduleHide"
     />

--- a/src/components/TaskList.vue
+++ b/src/components/TaskList.vue
@@ -1,0 +1,22 @@
+```vue
+<template>
+  <div class="task-list">
+    <TaskItem
+      v-for="task in tasks"
+      :key="task.id"
+      :task="task"
+    />
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { useTaskStore } from '@/store/task';
+import TaskItem from './TaskItem.vue';
+
+const store = useTaskStore();
+const tasks = computed(() => store.tasks);
+</script>
+
+<style scoped src="./styles/_task-list.scss"></style>
+```

--- a/src/components/TaskList.vue
+++ b/src/components/TaskList.vue
@@ -12,7 +12,7 @@
 <script setup>
 import { computed } from 'vue';
 import { useTaskStore } from '@/store/task';
-import TaskItem from './TaskItem.vue';
+import TaskItem from '@/components/TaskItem.vue';
 
 const store = useTaskStore();
 const tasks = computed(() => store.tasks);

--- a/src/components/TaskList.vue
+++ b/src/components/TaskList.vue
@@ -18,5 +18,7 @@ const store = useTaskStore();
 const tasks = computed(() => store.tasks);
 </script>
 
-<style scoped src="./styles/_task-list.scss"></style>
+<style scoped lang="scss">
+@import "./styles/_task-list.scss";
+</style>
 ```

--- a/src/utils/popper.js
+++ b/src/utils/popper.js
@@ -1,6 +1,17 @@
 import { createPopper } from '@popperjs/core'
 
-export function createPopperInstance(referenceEl, popperEl, config = {}) {
+/**
+ * Create a Popper.js instance with sensible defaults.
+ *
+ * @param {Element|HTMLElement} reference - The element the popper is positioned against.
+ * @param {Element|HTMLElement} popper - The popper element.
+ * @param {Object} [config={}] - Additional Popper configuration.
+ * @param {string} [config.placement='auto'] - Desired placement.
+ * @param {number[]} [config.offset=[0, 8]] - Offset modifier values.
+ * @param {Array} [config.modifiers=[]] - Extra modifiers.
+ * @returns {import('@popperjs/core').Instance} The created Popper instance.
+ */
+export function createPopperInstance(reference, popper, config = {}) {
   const {
     placement = 'auto',
     offset = [0, 8],
@@ -10,20 +21,25 @@ export function createPopperInstance(referenceEl, popperEl, config = {}) {
 
   const defaultModifiers = [
     { name: 'offset', options: { offset } },
-    { name: 'flip', options: { fallbackPlacements: ['top', 'bottom'] } },
+    { name: 'flip', options: { fallbackPlacements: ['top', 'bottom', 'right', 'left'] } },
     { name: 'preventOverflow', options: { padding: 8 } },
     ...modifiers,
   ]
 
-  return createPopper(referenceEl, popperEl, {
+  return createPopper(reference, popper, {
     placement,
     modifiers: defaultModifiers,
     ...rest,
   })
 }
 
+/**
+ * Safely destroy a Popper.js instance.
+ *
+ * @param {import('@popperjs/core').Instance|null|undefined} instance
+ */
 export function destroyPopper(instance) {
-  if (instance) {
+  if (instance && typeof instance.destroy === 'function') {
     instance.destroy()
   }
 }

--- a/src/utils/popper.js
+++ b/src/utils/popper.js
@@ -1,0 +1,25 @@
+import { createPopper } from '@popperjs/core'
+
+export function createPopperInstance(referenceEl, popperEl, config = {}) {
+  const {
+    placement = 'bottom',
+    offset = [0, 8],
+    modifiers = [],
+    ...rest
+  } = config
+
+  return createPopper(referenceEl, popperEl, {
+    placement,
+    modifiers: [
+      { name: 'offset', options: { offset } },
+      ...modifiers
+    ],
+    ...rest
+  })
+}
+
+export function destroyPopper(instance) {
+  if (instance) {
+    instance.destroy()
+  }
+}

--- a/src/utils/popper.js
+++ b/src/utils/popper.js
@@ -2,19 +2,23 @@ import { createPopper } from '@popperjs/core'
 
 export function createPopperInstance(referenceEl, popperEl, config = {}) {
   const {
-    placement = 'bottom',
+    placement = 'auto',
     offset = [0, 8],
     modifiers = [],
     ...rest
   } = config
 
+  const defaultModifiers = [
+    { name: 'offset', options: { offset } },
+    { name: 'flip', options: { fallbackPlacements: ['top', 'bottom'] } },
+    { name: 'preventOverflow', options: { padding: 8 } },
+    ...modifiers,
+  ]
+
   return createPopper(referenceEl, popperEl, {
     placement,
-    modifiers: [
-      { name: 'offset', options: { offset } },
-      ...modifiers
-    ],
-    ...rest
+    modifiers: defaultModifiers,
+    ...rest,
   })
 }
 

--- a/src/utils/popper.js
+++ b/src/utils/popper.js
@@ -1,16 +1,6 @@
+```js
 import { createPopper } from '@popperjs/core'
 
-/**
- * Create a Popper.js instance with sensible defaults.
- *
- * @param {Element|HTMLElement} reference - The element the popper is positioned against.
- * @param {Element|HTMLElement} popper - The popper element.
- * @param {Object} [config={}] - Additional Popper configuration.
- * @param {string} [config.placement='auto'] - Desired placement.
- * @param {number[]} [config.offset=[0, 8]] - Offset modifier values.
- * @param {Array} [config.modifiers=[]] - Extra modifiers.
- * @returns {import('@popperjs/core').Instance} The created Popper instance.
- */
 export function createPopperInstance(reference, popper, config = {}) {
   const {
     placement = 'auto',
@@ -33,13 +23,11 @@ export function createPopperInstance(reference, popper, config = {}) {
   })
 }
 
-/**
- * Safely destroy a Popper.js instance.
- *
- * @param {import('@popperjs/core').Instance|null|undefined} instance
- */
 export function destroyPopper(instance) {
   if (instance && typeof instance.destroy === 'function') {
     instance.destroy()
   }
 }
+
+export default createPopperInstance
+```

--- a/utils/popper.js
+++ b/utils/popper.js
@@ -1,0 +1,85 @@
+```js
+// src/utils/popper.js
+
+import { createPopper } from '@popperjs/core'
+
+/**
+ * Initialise a Popper.js instance.
+ *
+ * @param {HTMLElement} referenceEl – Element the popper is attached to.
+ * @param {HTMLElement} popperEl – Popper element.
+ * @param {Object} [options={}] – Popper options (see Popper docs).
+ * @returns {{
+ *   instance: import('@popperjs/core').Instance,
+ *   destroy: () => void,
+ *   update: () => Promise<void>
+ * }}
+ */
+export function initPopper (referenceEl, popperEl, options = {}) {
+  if (!referenceEl || !popperEl) {
+    throw new Error('Both referenceEl and popperEl must be provided to initPopper')
+  }
+
+  const defaultOptions = {
+    placement: 'auto',
+    modifiers: [
+      {
+        name: 'offset',
+        options: {
+          offset: [0, 8]
+        }
+      },
+      {
+        name: 'preventOverflow',
+        options: {
+          boundary: 'clippingParents'
+        }
+      }
+    ]
+  }
+
+  const popperInstance = createPopper(
+    referenceEl,
+    popperEl,
+    Object.assign({}, defaultOptions, options)
+  )
+
+  const destroy = () => {
+    popperInstance.destroy()
+  }
+
+  const update = () => {
+    return popperInstance.update()
+  }
+
+  // Re‑calculate on viewport changes
+  const resizeHandler = () => {
+    update()
+  }
+  window.addEventListener('resize', resizeHandler)
+
+  // Clean up the resize listener when the instance is destroyed
+  const originalDestroy = destroy
+  const wrappedDestroy = () => {
+    window.removeEventListener('resize', resizeHandler)
+    originalDestroy()
+  }
+
+  return {
+    instance: popperInstance,
+    destroy: wrappedDestroy,
+    update
+  }
+}
+
+/**
+ * Convenience wrapper to destroy a Popper instance.
+ *
+ * @param {{ destroy: Function }} popperObj
+ */
+export function disposePopper (popperObj) {
+  if (popperObj && typeof popperObj.destroy === 'function') {
+    popperObj.destroy()
+  }
+}
+```


### PR DESCRIPTION
Closes #1

## Plan
**Краткий план исправления поведения hover‑card**

| Шаг | Что делаем | Где правим |
|-----|------------|------------|
| **1. Перенести hover‑card в DOM‑дерево задачи** | Вместо того, чтобы рендерить карту в глобальном слое (например, через `teleport`), разместить её как дочерний элемент `TaskItem`. Это позволяет «захватить» событие `mouseenter`/`mouseleave` от обеих частей (строка задачи + карта). | `src/components/TaskItem.vue` (добавить `<HoverCard v‑if="showHover"/>` внутри шаблона) |
| **2. Управлять состоянием через реактивную переменную** | В `TaskItem.vue` создать `ref<boolean> showHover = false`. При `mouseenter` строки ставить `showHover = true`. При `mouseleave` – запускать таймаут (≈ 200 мс), который скроет карту, **если** мышь не вошла в саму карту. | `src/components/TaskItem.vue` (логика в `<script setup>` или `data()/methods`) |
| **3. Добавить обработчики `mouseenter`/`mouseleave` у HoverCard** | На карте отменять таймаут (чтобы карта не исчезла, пока курсор над ней) и, при уходе курсора с карты, запускать тот же таймаут скрытия. | `src/components/HoverCard.vue` (emit‑события `card-enter` / `card-leave` либо напрямую импортировать `showHover` через `props`/`emit`) |
| **4. Унифицировать таймаут в одном месте** | В `TaskItem.vue` вынести функцию `scheduleHide()` и `clearHide()`; оба компонента вызывают их через `emit` или через предоставление функции через `provide/inject`. Это избавит от «гонки» между задачами. | `src/components/TaskItem.vue` (все функции таймаута) |
| **5. Обновить позиционирование Popper** | После перемещения карты в дерево задачи, Popper‑instance нужно инициализировать **на этом элементе**, а не на корневом `body`. Передать `reference`‑элементом саму задачу, а `popper` – card‑wrapper. | `src/components/HoverCard.vue` (инициализация `createPopper(referenceEl, popperEl, { placement: 'bottom' })`) |
| **6. Подправить стили, чтобы карта не «прерывала» поток** | Убедиться, что карта имеет `position: absolute; pointer‑events: auto;` и `z-index` выше строки, но при этом не влияет на высоту строки (не менять `display`). При необходимости добавить небольшие `margin-top` / `margin-bottom` для визуального отступа. | `src/assets/styles/*.scss` (или `<style scoped>` внутри `HoverCard.vue`) |
| **7. Тестировать в разных условиях** | Проверить: <br>• карта появляется ниже и выше; <br>• переход курсора от строки к карте не прерывает её; <br>• при уходе курсора вниз появляется карта следующей задачи только после полного выхода из текущей; <br>• работа в Edge, Chrome, Firefox; <br>• сохранение поведения в compact‑view и при разных количествах колонок. | Локальное тестирование, CI (если есть). |

### Файлы, которые необходимо изменить

| Файл | Причина изменения |
|------|-------------------|
| `src/components/TaskItem.vue` | Добавление переменной `showHover`, обработчиков `mouseenter`/`mouseleave`, импорт/вставка `<HoverCard/>`, логика таймаута. |
| `src/components/HoverCard.vue` | Перевод компонента в «самостоятельный» элемент, инициализация Popper в `onMounted`, добавление `@mouseenter`/`@mouseleave`‑слушателей, экспорт событий `card-enter` / `card-leave`. |
| (опционально) `src/components/TaskList.vue` | Если список использует `v-for`‑ключи, убедиться, что `TaskItem` остаётся единичным контейнером без лишних `teleport`. |
| `src/assets/styles/_hover-card.scss` (или аналогичный) | Установить `position: absolute; pointer-events: auto; z-index: 1000;` и отступы, чтобы карта не перекрывала соседние строки визуально, но оставалась в DOM‑дереве задачи. |
| `src/utils/popper.js` (если есть отдельный помощник) | Обновить функцию создания Popper‑instance, чтобы принимать `referenceEl` из `TaskItem` и `popperEl` из `HoverCard`. |
| `src/store/...` (при необходимости) | Если состояние hover‑card хранится в Vuex, перенести его в локальный `ref` внутри `TaskItem` (чтобы не конфликтовать между задачами). |

После выполнения шагов выше hover‑card будет «принадлежать» задаче, а не отдельному слою, что устранит проблему переключения на следующую задачу при перемещении курсора вниз. Тесты и небольшие стилистические правки гарантируют, что поведение останется корректным в обоих направлениях (карту сверху и снизу).